### PR TITLE
Implement basic expense tracking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # CoinSync
+
+CoinSync is a simple expense tracking project used to share debts between members of a group. The current codebase provides a minimal REST API using Spring Boot with in-memory H2 database. Users can create rooms, invite members and register expenses associated with any room.
+
+The project still lacks a user interface and email integration but can be used as a starting point for further development.
+
+## Building
+
+The project uses Maven. Due to the environment restrictions of this repository the build might fail if dependencies are not cached locally.
+
+```bash
+mvn test
+```

--- a/coinsync/coinsync/pom.xml
+++ b/coinsync/coinsync/pom.xml
@@ -30,10 +30,23 @@
 		<java.version>17</java.version>
 	</properties>
 	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>com.h2database</groupId>
+                        <artifactId>h2</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/ExpenseController.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/ExpenseController.java
@@ -1,0 +1,41 @@
+package com.github.KdAndrade.coinsync.controller;
+
+import com.github.KdAndrade.coinsync.expense.Expense;
+import com.github.KdAndrade.coinsync.repository.ExpenseRepository;
+import com.github.KdAndrade.coinsync.repository.RoomRepository;
+import com.github.KdAndrade.coinsync.repository.UserRepository;
+import com.github.KdAndrade.coinsync.room.Room;
+import com.github.KdAndrade.coinsync.user.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/expenses")
+public class ExpenseController {
+
+    private final ExpenseRepository expenseRepository;
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+
+    public ExpenseController(ExpenseRepository expenseRepository, UserRepository userRepository, RoomRepository roomRepository) {
+        this.expenseRepository = expenseRepository;
+        this.userRepository = userRepository;
+        this.roomRepository = roomRepository;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Expense create(@RequestBody Expense expense) {
+        return expenseRepository.save(expense);
+    }
+
+    @GetMapping("/room/{roomId}")
+    public List<Expense> listByRoom(@PathVariable Long roomId) {
+        Room room = roomRepository.findById(roomId).orElseThrow();
+        return expenseRepository.findAll().stream()
+                .filter(e -> room.equals(e.getRoom()))
+                .toList();
+    }
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/RoomController.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/RoomController.java
@@ -1,0 +1,42 @@
+package com.github.KdAndrade.coinsync.controller;
+
+import com.github.KdAndrade.coinsync.repository.RoomRepository;
+import com.github.KdAndrade.coinsync.repository.UserRepository;
+import com.github.KdAndrade.coinsync.room.Room;
+import com.github.KdAndrade.coinsync.user.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/rooms")
+public class RoomController {
+
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+
+    public RoomController(RoomRepository roomRepository, UserRepository userRepository) {
+        this.roomRepository = roomRepository;
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Room create(@RequestBody Room room) {
+        return roomRepository.save(room);
+    }
+
+    @PostMapping("/{roomId}/members/{userId}")
+    public Room addMember(@PathVariable Long roomId, @PathVariable Long userId) {
+        Room room = roomRepository.findById(roomId).orElseThrow();
+        User user = userRepository.findById(userId).orElseThrow();
+        room.getMembers().add(user);
+        return roomRepository.save(room);
+    }
+
+    @GetMapping
+    public List<Room> list() {
+        return roomRepository.findAll();
+    }
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/UserController.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/controller/UserController.java
@@ -1,0 +1,30 @@
+package com.github.KdAndrade.coinsync.controller;
+
+import com.github.KdAndrade.coinsync.repository.UserRepository;
+import com.github.KdAndrade.coinsync.user.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserRepository userRepository;
+
+    public UserController(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public User create(@RequestBody User user) {
+        return userRepository.save(user);
+    }
+
+    @GetMapping
+    public List<User> list() {
+        return userRepository.findAll();
+    }
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/expense/Expense.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/expense/Expense.java
@@ -1,5 +1,90 @@
 package com.github.KdAndrade.coinsync.expense;
 
-public class Expense {
+import com.github.KdAndrade.coinsync.room.Room;
+import com.github.KdAndrade.coinsync.user.User;
+import jakarta.persistence.*;
 
+import java.math.BigDecimal;
+
+@Entity
+public class Expense {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private BigDecimal value;
+    @ManyToOne
+    private User debtor;
+    @ManyToOne
+    private User creditor;
+    @ManyToOne
+    private Room room;
+    private boolean isPrivate;
+
+    public Expense() {}
+
+    public Expense(String title, BigDecimal value, User debtor, User creditor, Room room, boolean isPrivate) {
+        this.title = title;
+        this.value = value;
+        this.debtor = debtor;
+        this.creditor = creditor;
+        this.room = room;
+        this.isPrivate = isPrivate;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public BigDecimal getValue() {
+        return value;
+    }
+
+    public void setValue(BigDecimal value) {
+        this.value = value;
+    }
+
+    public User getDebtor() {
+        return debtor;
+    }
+
+    public void setDebtor(User debtor) {
+        this.debtor = debtor;
+    }
+
+    public User getCreditor() {
+        return creditor;
+    }
+
+    public void setCreditor(User creditor) {
+        this.creditor = creditor;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public boolean isPrivate() {
+        return isPrivate;
+    }
+
+    public void setPrivate(boolean aPrivate) {
+        isPrivate = aPrivate;
+    }
 }

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/ExpenseRepository.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/ExpenseRepository.java
@@ -1,0 +1,7 @@
+package com.github.KdAndrade.coinsync.repository;
+
+import com.github.KdAndrade.coinsync.expense.Expense;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExpenseRepository extends JpaRepository<Expense, Long> {
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/RoomRepository.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.github.KdAndrade.coinsync.repository;
+
+import com.github.KdAndrade.coinsync.room.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/UserRepository.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.github.KdAndrade.coinsync.repository;
+
+import com.github.KdAndrade.coinsync.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/room/Room.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/room/Room.java
@@ -1,0 +1,50 @@
+package com.github.KdAndrade.coinsync.room;
+
+import com.github.KdAndrade.coinsync.user.User;
+import jakarta.persistence.*;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+public class Room {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+
+    @ManyToMany
+    @JoinTable(name = "room_members",
+            joinColumns = @JoinColumn(name = "room_id"),
+            inverseJoinColumns = @JoinColumn(name = "user_id"))
+    private Set<User> members = new HashSet<>();
+
+    public Room() {}
+
+    public Room(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<User> getMembers() {
+        return members;
+    }
+
+    public void setMembers(Set<User> members) {
+        this.members = members;
+    }
+}

--- a/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/user/User.java
+++ b/coinsync/coinsync/src/main/java/com/github/KdAndrade/coinsync/user/User.java
@@ -1,0 +1,46 @@
+package com.github.KdAndrade.coinsync.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String email;
+
+    public User() {}
+
+    public User(String name, String email) {
+        this.name = name;
+        this.email = email;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/coinsync/coinsync/src/main/resources/application.properties
+++ b/coinsync/coinsync/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=CoinSync
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
## Summary
- flesh out README with project overview
- add web & JPA dependencies
- implement `User`, `Room`, `Expense` entities
- create repositories and REST controllers for basic CRUD
- enable H2 database

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_688591743b248329a627c959eda08025